### PR TITLE
fix items size: allows not to send useless nils

### DIFF
--- a/async.go
+++ b/async.go
@@ -64,7 +64,7 @@ func (b *AsyncBatcher[Item]) Shutdown() {
 }
 
 func collect[Item any](batchCh <-chan Item, size int64, timeout time.Duration, wbf AsyncBatchFunc[Item]) {
-	items := make([]Item, size)
+	items := make([]Item, 0, size)
 
 	t := acquireTimer(timeout)
 


### PR DESCRIPTION
Fixes batching behaviour for async batcher.

without this change it will always send the whole batch, even if it's just 99 nils and 1 element.